### PR TITLE
Fixed overlay state

### DIFF
--- a/lib/polymer_datepicker.dart
+++ b/lib/polymer_datepicker.dart
@@ -198,6 +198,11 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
   }
 
   @reflectable
+  void doClose(Event e, var detail) {
+	  pickerOpen = false;
+  }
+
+  @reflectable
   void nextMonth([_,__]) {
     currentDate = currentDate.subtract(new Duration(days:currentDate.day-1));
     currentDate = currentDate.add(new Duration(days:32));

--- a/lib/polymer_datepicker.dart
+++ b/lib/polymer_datepicker.dart
@@ -198,11 +198,6 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
   }
 
   @reflectable
-  void doClose(Event e, var detail) {
-	  pickerOpen = false;
-  }
-
-  @reflectable
   void nextMonth([_,__]) {
     currentDate = currentDate.subtract(new Duration(days:currentDate.day-1));
     currentDate = currentDate.add(new Duration(days:32));

--- a/lib/polymer_datepicker.html
+++ b/lib/polymer_datepicker.html
@@ -139,7 +139,7 @@
           <paper-input disabled="[[disabled]]" id="input" on-click="showPicker" required="[[required]]" auto-validate="" value="{{textDate}}" label="[[label]]" on-blur="inputLeft" class$="[[computeInputClass(dateonly)]]"></paper-input>
         </div>
         <div style="position:relative">
-            <date-picker-overlay id="pick" style="position:absolute;left:0;top:0" autofocusdisabled="true" autoclosedisabled="true" opened="[[pickerOpen]]" on-iron-overlay-opened="doPos" on-iron-overlay-closed="doClose" on-mousedown="cancelClose">
+            <date-picker-overlay id="pick" style="position:absolute;left:0;top:0" autofocusdisabled="true" autoclosedisabled="true" opened="{{pickerOpen}}" on-iron-overlay-opened="doPos" on-mousedown="cancelClose">
                 <paper-material elevation="2">
 
                 <div id="month" layout="" vertical="" class="monthCell">

--- a/lib/polymer_datepicker.html
+++ b/lib/polymer_datepicker.html
@@ -139,7 +139,7 @@
           <paper-input disabled="[[disabled]]" id="input" on-click="showPicker" required="[[required]]" auto-validate="" value="{{textDate}}" label="[[label]]" on-blur="inputLeft" class$="[[computeInputClass(dateonly)]]"></paper-input>
         </div>
         <div style="position:relative">
-            <date-picker-overlay id="pick" style="position:absolute;left:0;top:0" autofocusdisabled="true" autoclosedisabled="true" opened="[[pickerOpen]]" on-iron-overlay-opened="doPos" on-mousedown="cancelClose">
+            <date-picker-overlay id="pick" style="position:absolute;left:0;top:0" autofocusdisabled="true" autoclosedisabled="true" opened="[[pickerOpen]]" on-iron-overlay-opened="doPos" on-iron-overlay-closed="doClose" on-mousedown="cancelClose">
                 <paper-material elevation="2">
 
                 <div id="month" layout="" vertical="" class="monthCell">


### PR DESCRIPTION
Fixed an issue that manifested when you would click outside the bounds of the overlay box, and the overlay would close. You would have to click the input box 4 times to open the overlay again.
