### PR TITLE
Ease of use

### DIFF
--- a/lib/polymer_datepicker.dart
+++ b/lib/polymer_datepicker.dart
@@ -287,8 +287,13 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
         first = first.subtract(new Duration(days:1));
       }
       month = new List.generate(6, (int w) => new Week(first.add(new Duration(days:7*w)),currentDate.month,selectedDate),growable: true);
-      if (month.last.days[0].other)
-	    month.removeLast();
+
+      bool others = true;
+      while(others) {
+	    if (month.last.days[0].other)
+		    month.removeLast();
+	    else others = false;
+      }
       firstWeek = month.first;
   }
 

--- a/lib/polymer_datepicker.dart
+++ b/lib/polymer_datepicker.dart
@@ -286,7 +286,9 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
       while (first.weekday!=(startWithSunday ? DateTime.SUNDAY : DateTime.MONDAY)) {
         first = first.subtract(new Duration(days:1));
       }
-      month = new List.generate(6, (int w) => new Week(first.add(new Duration(days:7*w)),currentDate.month,selectedDate));
+      month = new List.generate(6, (int w) => new Week(first.add(new Duration(days:7*w)),currentDate.month,selectedDate),growable: true);
+      if (month.last.days[0].other)
+	    month.removeLast();
       firstWeek = month.first;
   }
 

--- a/lib/polymer_datepicker.dart
+++ b/lib/polymer_datepicker.dart
@@ -108,7 +108,8 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
   @observable @property String label;
 
   /// A flag to select only date without time info (default: false)
-  @observable @property bool dateonly = false;
+  @deprecated @observable @property bool dateonly = false;
+  @observable @property bool dateOnly = false;
 
   @observable @property List<Week> month;
 
@@ -142,7 +143,7 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
   
   DatePicker.created() : super.created() {
     format = new DateFormat.yMd();
-    if (!dateonly) {
+    if (!dateOnly && !dateonly) {
       format.add_Hm();
     }
     currentDate = new DateTime.now();
@@ -154,10 +155,10 @@ class DatePicker extends PolymerElement with Observable, AutonotifyBehavior {
   /// The date format (default: locale for `DateFormat.yMd`)
   @observable @property String dateFormat = new DateFormat.yMd().pattern;
 
-  @Observe("dateonly,dateFormat")
+  @Observe("dateOnly,dateonly,dateFormat")
   void changeDateFormat([_,__]) {
     format = new DateFormat(dateFormat);
-    if (!dateonly) {
+    if (!dateOnly && !dateonly) {
       format.add_Hm();
     }
     if (selectedDate!=null) {


### PR DESCRIPTION
Removing full weeks at the end of the months that are in the next month (the other bool) from showing up
added dateOnly (camel cased) to match all other multi-worded variables
deprecated dateonly (all lower)
Added start with Sunday flag, because not everyone uses a calendar with Sunday on the end of the week (North America)
Changed weekDay to be an observable string, the property wasn't updating the DOM.
null aware variable checks
